### PR TITLE
Fix seek call raising UnsupportedOperationException

### DIFF
--- a/shapefile.py
+++ b/shapefile.py
@@ -240,17 +240,26 @@ class Reader:
             if hasattr(kwargs["shp"], "read"):
                 self.shp = kwargs["shp"]
                 if hasattr(self.shp, "seek"):
-                    self.shp.seek(0)
+                    try:
+                        self.shp.seek(0)
+                    except UnsupportedOperationException:
+                        pass
             if "shx" in kwargs.keys():
                 if hasattr(kwargs["shx"], "read"):
                     self.shx = kwargs["shx"]
                     if hasattr(self.shx, "seek"):
-                        self.shx.seek(0)
+                        try:
+                            self.shp.seek(0)
+                        except UnsupportedOperationException:
+                            pass
         if "dbf" in kwargs.keys():
             if hasattr(kwargs["dbf"], "read"):
                 self.dbf = kwargs["dbf"]
                 if hasattr(self.dbf, "seek"):
-                    self.dbf.seek(0)
+                    try:
+                        self.shp.seek(0)
+                    except UnsupportedOperationException:
+                        pass
         if self.shp or self.dbf:        
             self.load()
         else:


### PR DESCRIPTION
There are some file-like object implementation, most notably in the Python standard library (`zipfile.ZipExtFile`), where `hasattr(filelike, "seek")` returns `True` but calling `seek()` raises `UnsupportedOperationException`.

This PR fixes this by catching `UnsupportedOperationException`, in effect handling it as if `hasattr(filelike, "seek")` returns `False`.

If required, I can provide a full example showing the issue (i.e. reading directly from a ZIP without unzipping, which I'm currently writing a blogpost about).

